### PR TITLE
RedisConnectionのラッパー - [Phase 3] HookStorage: 既存フックの対応 の実装

### DIFF
--- a/src/Hook/FallbackReadHook.php
+++ b/src/Hook/FallbackReadHook.php
@@ -39,7 +39,17 @@ class FallbackReadHook implements ReadHookInterface
     {
     }
 
-    public function afterRead(string $sessionId, string $data): string
+    /**
+     * Called after reading session data from Redis.
+     *
+     * Returns the data unchanged (fallback logic is handled in onReadError).
+     *
+     * @param string $sessionId The session ID
+     * @param string $data The session data read from Redis
+     * @param Storage\HookStorageInterface|null $storage Optional HookStorage (not used in this hook)
+     * @return string The unmodified session data
+     */
+    public function afterRead(string $sessionId, string $data, ?Storage\HookStorageInterface $storage = null): string
     {
         return $data;
     }

--- a/src/Hook/LoggingHook.php
+++ b/src/Hook/LoggingHook.php
@@ -63,7 +63,17 @@ class LoggingHook implements WriteHookInterface
         $this->logData = $logData;
     }
 
-    public function beforeWrite(string $sessionId, array $data): array
+    /**
+     * Called before writing session data to Redis.
+     *
+     * Logs the session write operation with configured log level.
+     *
+     * @param string $sessionId The session ID
+     * @param array<string, mixed> $data The unserialized session data
+     * @param Storage\HookStorageInterface|null $storage Optional HookStorage (not used in this hook)
+     * @return array<string, mixed> The unmodified session data
+     */
+    public function beforeWrite(string $sessionId, array $data, ?Storage\HookStorageInterface $storage = null): array
     {
         $context = [
             'session_id' => SessionIdMasker::mask($sessionId),

--- a/src/Hook/ReadHookInterface.php
+++ b/src/Hook/ReadHookInterface.php
@@ -6,6 +6,14 @@ namespace Uzulla\EnhancedRedisSessionHandler\Hook;
 
 use Throwable;
 
+/**
+ * Interface for hooks that intercept session read operations.
+ *
+ * Implementations can perform operations before reading, modify session data
+ * after reading, or handle read errors.
+ *
+ * @see Storage\HookStorageInterface For safe Redis operations within hooks
+ */
 interface ReadHookInterface
 {
     /**
@@ -18,11 +26,16 @@ interface ReadHookInterface
     /**
      * Called after reading session data from Redis.
      *
+     * Implementations can modify the session data after it is read.
+     * If HookStorage is provided, it should be used for any Redis operations
+     * to prevent infinite recursion through depth tracking.
+     *
      * @param string $sessionId The session ID
      * @param string $data The session data read from Redis
+     * @param Storage\HookStorageInterface|null $storage Optional HookStorage for safe Redis operations
      * @return string The modified session data
      */
-    public function afterRead(string $sessionId, string $data): string;
+    public function afterRead(string $sessionId, string $data, ?Storage\HookStorageInterface $storage = null): string;
 
     /**
      * Called when an error occurs during read operation.

--- a/src/Hook/ReadTimestampHook.php
+++ b/src/Hook/ReadTimestampHook.php
@@ -92,17 +92,18 @@ class ReadTimestampHook implements ReadHookInterface
                     'session_id' => SessionIdMasker::mask($sessionId),
                     'timestamp' => $timestamp,
                 ]);
-            } else {
-                $this->connection->set($timestampKey, $timestamp, $this->timestampTtl);
-                $this->logger->debug('Recorded session read timestamp via direct connection', [
-                    'session_id' => SessionIdMasker::mask($sessionId),
-                    'timestamp' => $timestamp,
-                ]);
+                return;
             }
-        } catch (Throwable $e) {
+
+            $this->connection->set($timestampKey, $timestamp, $this->timestampTtl);
+            $this->logger->debug('Recorded session read timestamp via direct connection', [
+                'session_id' => SessionIdMasker::mask($sessionId),
+                'timestamp' => $timestamp,
+            ]);
+        } catch (Throwable $ex) {
             $this->logger->warning('Failed to record session read timestamp', [
                 'session_id' => SessionIdMasker::mask($sessionId),
-                'exception' => $e,
+                'exception' => $ex,
             ]);
         }
     }

--- a/src/Hook/ReadTimestampHook.php
+++ b/src/Hook/ReadTimestampHook.php
@@ -51,6 +51,13 @@ class ReadTimestampHook implements ReadHookInterface
         $this->timestampTtl = $timestampTtl;
     }
 
+    /**
+     * Called before reading session data from Redis.
+     *
+     * This hook does not perform any action before reading.
+     *
+     * @param string $sessionId The session ID
+     */
     public function beforeRead(string $sessionId): void
     {
     }
@@ -69,6 +76,15 @@ class ReadTimestampHook implements ReadHookInterface
         return $data;
     }
 
+    /**
+     * Called when an error occurs during the read operation.
+     *
+     * This hook does not provide fallback data for read errors.
+     *
+     * @param string $sessionId The session ID
+     * @param Throwable $e The exception that occurred during read
+     * @return null Always returns null (no fallback data)
+     */
     public function onReadError(string $sessionId, Throwable $e): ?string
     {
         return null;

--- a/src/Hook/SessionMigrationHook.php
+++ b/src/Hook/SessionMigrationHook.php
@@ -135,7 +135,17 @@ class SessionMigrationHook implements WriteHookInterface
         return $this->targetSessionId;
     }
 
-    public function beforeWrite(string $sessionId, array $data): array
+    /**
+     * Called before writing session data to Redis.
+     *
+     * Stores the session data for potential migration in afterWrite.
+     *
+     * @param string $sessionId The session ID
+     * @param array<string, mixed> $data The unserialized session data
+     * @param Storage\HookStorageInterface|null $storage Optional HookStorage (not used in this hook)
+     * @return array<string, mixed> The unmodified session data
+     */
+    public function beforeWrite(string $sessionId, array $data, ?Storage\HookStorageInterface $storage = null): array
     {
         // afterWriteで使用するためデータを保存
         $this->pendingWrites[$sessionId] = $data;

--- a/src/Hook/WriteHookInterface.php
+++ b/src/Hook/WriteHookInterface.php
@@ -6,16 +6,29 @@ namespace Uzulla\EnhancedRedisSessionHandler\Hook;
 
 use Throwable;
 
+/**
+ * Interface for hooks that intercept session write operations.
+ *
+ * Implementations can modify session data before writing, perform additional
+ * operations after writing, or handle write errors.
+ *
+ * @see Storage\HookStorageInterface For safe Redis operations within hooks
+ */
 interface WriteHookInterface
 {
     /**
      * Called before writing session data to Redis.
      *
+     * Implementations can modify the session data before it is written.
+     * If HookStorage is provided, it should be used for any Redis operations
+     * to prevent infinite recursion through depth tracking.
+     *
      * @param string $sessionId The session ID
      * @param array<string, mixed> $data The unserialized session data
+     * @param Storage\HookStorageInterface|null $storage Optional HookStorage for safe Redis operations
      * @return array<string, mixed> The modified session data
      */
-    public function beforeWrite(string $sessionId, array $data): array;
+    public function beforeWrite(string $sessionId, array $data, ?Storage\HookStorageInterface $storage = null): array;
 
     /**
      * Called after writing session data to Redis.

--- a/tests/Hook/DoubleWriteHookTest.php
+++ b/tests/Hook/DoubleWriteHookTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Uzulla\EnhancedRedisSessionHandler\Tests\Hook;
 
 use InvalidArgumentException;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Uzulla\EnhancedRedisSessionHandler\Hook\DoubleWriteHook;
+use Uzulla\EnhancedRedisSessionHandler\Hook\Storage\HookStorageInterface;
 use Uzulla\EnhancedRedisSessionHandler\RedisConnection;
 
 class DoubleWriteHookTest extends TestCase
@@ -159,5 +162,198 @@ class DoubleWriteHookTest extends TestCase
 
         // 例外が投げられないことを確認（モックの期待値がチェックされる）
         $this->addToAssertionCount(1);
+    }
+
+    // ========================================
+    // HookStorage対応テスト
+    // ========================================
+
+    public function testConstructorWithUseHookStorageFlag(): void
+    {
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, null, true);
+        self::assertInstanceOf(DoubleWriteHook::class, $hook);
+    }
+
+    public function testBeforeWriteWithHookStorageStoresStorage(): void
+    {
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, null, true);
+        $data = ['user_id' => 123, 'username' => 'test'];
+
+        $result = $hook->beforeWrite('test_session', $data, $mockStorage);
+
+        self::assertSame($data, $result);
+    }
+
+    public function testAfterWriteWithHookStorageUsesStorageForSecondaryWrite(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+        $mockStorage->expects(self::once())
+            ->method('set')
+            ->with(
+                'test_session',
+                self::anything(),
+                1440
+            )
+            ->willReturn(true);
+
+        // secondaryConnectionは使われない
+        $this->secondaryConnection->expects(self::never())
+            ->method('set');
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, $logger, true);
+        $hook->beforeWrite('test_session', ['key' => 'value'], $mockStorage);
+        $hook->afterWrite('test_session', true);
+
+        // HookStorage経由のログメッセージを確認
+        self::assertTrue($testHandler->hasDebugThatContains('via HookStorage'));
+    }
+
+    public function testAfterWriteWithoutHookStorageUsesDirectConnection(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $this->secondaryConnection->expects(self::once())
+            ->method('set')
+            ->with(
+                'test_session',
+                self::anything(),
+                1440
+            )
+            ->willReturn(true);
+
+        // useHookStorage=trueでも、storageが渡されなければdirect connectionを使用
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, $logger, true);
+        $hook->beforeWrite('test_session', ['key' => 'value']);
+        $hook->afterWrite('test_session', true);
+
+        // direct connection経由のログメッセージを確認
+        self::assertTrue($testHandler->hasDebugThatContains('via direct connection'));
+    }
+
+    public function testAfterWriteWithHookStorageDisabledUsesDirectConnection(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+        // storageは使われない
+        $mockStorage->expects(self::never())
+            ->method('set');
+
+        // useHookStorage=false（デフォルト）の場合、storageが渡されてもdirect connectionを使用
+        $this->secondaryConnection->expects(self::once())
+            ->method('set')
+            ->willReturn(true);
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, $logger, false);
+        $hook->beforeWrite('test_session', ['key' => 'value'], $mockStorage);
+        $hook->afterWrite('test_session', true);
+
+        // direct connection経由のログメッセージを確認
+        self::assertTrue($testHandler->hasDebugThatContains('via direct connection'));
+    }
+
+    public function testAfterWriteWithHookStorageHandlesFailure(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+        $mockStorage->expects(self::once())
+            ->method('set')
+            ->willReturn(false);
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, $logger, true);
+        $hook->beforeWrite('test_session', ['key' => 'value'], $mockStorage);
+        $hook->afterWrite('test_session', true);
+
+        // 書き込み失敗のエラーログが出力されていることを確認
+        self::assertTrue($testHandler->hasErrorThatContains('Secondary Redis write failed'));
+    }
+
+    public function testAfterWriteWithHookStorageThrowsExceptionOnFailure(): void
+    {
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+        $mockStorage->expects(self::once())
+            ->method('set')
+            ->willReturn(false);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Secondary Redis write failed');
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, true, null, true);
+        $hook->beforeWrite('test_session', ['key' => 'value'], $mockStorage);
+        $hook->afterWrite('test_session', true);
+    }
+
+    public function testOnWriteErrorCleansUpPendingStorages(): void
+    {
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+        // storageは使われない（エラーでクリーンアップされるため）
+        $mockStorage->expects(self::never())
+            ->method('set');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with('Primary write error, secondary write skipped', self::anything());
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, $logger, true);
+        $hook->beforeWrite('test_session', ['key' => 'value'], $mockStorage);
+        $hook->onWriteError('test_session', new \Exception('Test error'));
+
+        // 後続のafterWriteでstorageが使われないことを確認
+        $this->secondaryConnection->expects(self::never())
+            ->method('set');
+    }
+
+    public function testPrimaryWriteFailureCleansUpPendingStorages(): void
+    {
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+        // storageは使われない（プライマリ失敗でスキップされるため）
+        $mockStorage->expects(self::never())
+            ->method('set');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with('Primary write failed, skipping secondary write', self::anything());
+
+        // secondaryConnectionも使われない
+        $this->secondaryConnection->expects(self::never())
+            ->method('set');
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, $logger, true);
+        $hook->beforeWrite('test_session', ['key' => 'value'], $mockStorage);
+        $hook->afterWrite('test_session', false);
+    }
+
+    public function testBackwardCompatibilityWithoutStorageParameter(): void
+    {
+        // 新しいパラメータを使わずに従来の使い方ができることを確認
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $this->secondaryConnection->expects(self::once())
+            ->method('set')
+            ->willReturn(true);
+
+        $hook = new DoubleWriteHook($this->secondaryConnection, 1440, false, $logger);
+        $hook->beforeWrite('test_session', ['key' => 'value']);
+        $hook->afterWrite('test_session', true);
+
+        // direct connection経由のログメッセージを確認
+        self::assertTrue($testHandler->hasDebugThatContains('via direct connection'));
     }
 }

--- a/tests/Hook/ReadHookTest.php
+++ b/tests/Hook/ReadHookTest.php
@@ -10,6 +10,7 @@ use Throwable;
 use Uzulla\EnhancedRedisSessionHandler\Config\RedisConnectionConfig;
 use Uzulla\EnhancedRedisSessionHandler\Config\RedisSessionHandlerOptions;
 use Uzulla\EnhancedRedisSessionHandler\Hook\ReadHookInterface;
+use Uzulla\EnhancedRedisSessionHandler\Hook\Storage\HookStorageInterface;
 use Uzulla\EnhancedRedisSessionHandler\RedisConnection;
 use Uzulla\EnhancedRedisSessionHandler\RedisSessionHandler;
 use Uzulla\EnhancedRedisSessionHandler\Serializer\PhpSerializeSerializer;
@@ -60,7 +61,7 @@ class ReadHookTest extends TestCase
                 $this->testState->sessionId = $sessionId;
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 return $data;
             }
@@ -87,7 +88,7 @@ class ReadHookTest extends TestCase
             {
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 return 'modified:' . $data;
             }
@@ -132,7 +133,7 @@ class ReadHookTest extends TestCase
                 $this->testState->order = $order;
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 /** @var array<string> $order */
                 $order = $this->testState->order;
@@ -163,7 +164,7 @@ class ReadHookTest extends TestCase
                 $this->testState->order = $order;
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 /** @var array<string> $order */
                 $order = $this->testState->order;
@@ -211,7 +212,7 @@ class ReadHookTest extends TestCase
             {
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 throw new RuntimeException('Test error');
             }
@@ -245,7 +246,7 @@ class ReadHookTest extends TestCase
             {
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 throw new RuntimeException('Test error');
             }
@@ -275,7 +276,7 @@ class ReadHookTest extends TestCase
             {
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 throw new RuntimeException('Test error');
             }
@@ -291,7 +292,7 @@ class ReadHookTest extends TestCase
             {
             }
 
-            public function afterRead(string $sessionId, string $data): string
+            public function afterRead(string $sessionId, string $data, ?HookStorageInterface $storage = null): string
             {
                 return $data;
             }

--- a/tests/Hook/ReadTimestampHookTest.php
+++ b/tests/Hook/ReadTimestampHookTest.php
@@ -1,15 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Uzulla\EnhancedRedisSessionHandler\Tests\Hook;
 
 use InvalidArgumentException;
 use Monolog\Handler\NullHandler;
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Redis;
 use RuntimeException;
 use Uzulla\EnhancedRedisSessionHandler\Config\RedisConnectionConfig;
 use Uzulla\EnhancedRedisSessionHandler\Hook\ReadTimestampHook;
+use Uzulla\EnhancedRedisSessionHandler\Hook\Storage\HookContext;
+use Uzulla\EnhancedRedisSessionHandler\Hook\Storage\HookRedisStorage;
+use Uzulla\EnhancedRedisSessionHandler\Hook\Storage\HookStorageInterface;
 use Uzulla\EnhancedRedisSessionHandler\RedisConnection;
 use Uzulla\EnhancedRedisSessionHandler\Tests\Support\RedisIntegrationTestTrait;
 
@@ -147,5 +153,136 @@ class ReadTimestampHookTest extends TestCase
     {
         $hook = new ReadTimestampHook($this->connection, $this->logger, 'x');
         self::assertInstanceOf(ReadTimestampHook::class, $hook);
+    }
+
+    // ========================================
+    // HookStorage対応テスト
+    // ========================================
+
+    public function testAfterReadWithHookStorageRecordsTimestamp(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $hook = new ReadTimestampHook($this->connection, $logger, 'storage_read_at:', 3600);
+
+        $context = new HookContext(3);
+        $storage = new HookRedisStorage($this->connection, $context, $logger);
+
+        $data = 'test-data';
+        $result = $hook->afterRead('test-session-id', $data, $storage);
+
+        self::assertSame($data, $result);
+
+        $timestampKey = 'storage_read_at:test-session-id';
+        $timestamp = $this->connection->get($timestampKey);
+
+        self::assertNotFalse($timestamp);
+        self::assertGreaterThan(0, (int) $timestamp);
+
+        // HookStorage経由のログメッセージを確認
+        self::assertTrue($testHandler->hasDebugThatContains('via HookStorage'));
+
+        $this->connection->delete($timestampKey);
+    }
+
+    public function testAfterReadWithNullStorageUsesDirectConnection(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $hook = new ReadTimestampHook($this->connection, $logger, 'direct_read_at:', 3600);
+
+        $data = 'test-data';
+        $result = $hook->afterRead('test-session-id', $data, null);
+
+        self::assertSame($data, $result);
+
+        $timestampKey = 'direct_read_at:test-session-id';
+        $timestamp = $this->connection->get($timestampKey);
+
+        self::assertNotFalse($timestamp);
+
+        // direct connection経由のログメッセージを確認
+        self::assertTrue($testHandler->hasDebugThatContains('via direct connection'));
+
+        $this->connection->delete($timestampKey);
+    }
+
+    public function testAfterReadWithoutStorageParameterUsesDirectConnection(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $hook = new ReadTimestampHook($this->connection, $logger, 'no_param_read_at:', 3600);
+
+        $data = 'test-data';
+        // storageパラメータを渡さない（後方互換性テスト）
+        $result = $hook->afterRead('test-session-id', $data);
+
+        self::assertSame($data, $result);
+
+        $timestampKey = 'no_param_read_at:test-session-id';
+        $timestamp = $this->connection->get($timestampKey);
+
+        self::assertNotFalse($timestamp);
+
+        // direct connection経由のログメッセージを確認
+        self::assertTrue($testHandler->hasDebugThatContains('via direct connection'));
+
+        $this->connection->delete($timestampKey);
+    }
+
+    public function testAfterReadWithHookStorageHandlesErrors(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        // 無効な接続を使用してエラーをシミュレート
+        $redis = new Redis();
+        $config = new RedisConnectionConfig('invalid-host', 6379);
+        $invalidConnection = new RedisConnection($redis, $config, $logger);
+
+        $hook = new ReadTimestampHook($invalidConnection, $logger, 'error_read_at:', 3600);
+
+        $context = new HookContext(3);
+        $storage = new HookRedisStorage($invalidConnection, $context, $logger);
+
+        $data = 'test-data';
+        // エラーが発生してもデータはそのまま返される
+        $result = $hook->afterRead('test-session-id', $data, $storage);
+
+        self::assertSame($data, $result);
+
+        // エラーログが出力されていることを確認
+        self::assertTrue($testHandler->hasWarningThatContains('Failed to record session read timestamp'));
+    }
+
+    public function testAfterReadWithMockHookStorage(): void
+    {
+        $testHandler = new TestHandler();
+        $logger = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $hook = new ReadTimestampHook($this->connection, $logger, 'mock_read_at:', 3600);
+
+        $mockStorage = $this->createMock(HookStorageInterface::class);
+        $mockStorage->expects(self::once())
+            ->method('set')
+            ->with(
+                'mock_read_at:test-session-id',
+                self::anything(),
+                3600
+            )
+            ->willReturn(true);
+
+        $data = 'test-data';
+        $result = $hook->afterRead('test-session-id', $data, $mockStorage);
+
+        self::assertSame($data, $result);
     }
 }


### PR DESCRIPTION
ref: #101 

Summary

  - Phase 3実装: ReadTimestampHookとDoubleWriteHookをHookStorageパターンに対応
  - afterRead/beforeWriteメソッドにオプションのHookStorageInterfaceパラメータを追加
  - HookStorageが提供された場合はそれを経由、提供されない場合は直接接続を使用（後方互換性維持）
  - ログメッセージで使用した方式を区別（"via HookStorage" / "via direct connection"）
  - PHPMDのElseExpression警告に対応し、早期リターンパターンを採用

  Test plan

  - composer phpstan がエラーなしで完了すること
  - composer cs-check がエラーなしで完了すること
  - composer test で全テストがパスすること
  - ReadTimestampHookのHookStorage対応テスト（5テスト追加）
    - HookStorage経由のタイムスタンプ記録
    - null storage時のdirect connection使用
    - パラメータ省略時の後方互換性
    - エラーハンドリング
    - モックを使用したテスト
  - DoubleWriteHookのHookStorage対応テスト（9テスト追加）
    - storage保存
    - HookStorage経由の書き込み
    - storage未提供時のdirect connection
    - 失敗時のエラーログ・例外
    - エラー時のクリーンアップ
    - 後方互換性


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * フック処理でオプションのストレージレイヤーを受け取れるようになり、二次書き込みや読み取りタイムスタンプの記録がストレージ経由でも動作します。
  * 二次書き込みの実行・ログとエラーハンドリング、クリーンアップが強化され、直接接続／ストレージ経由の双方で一貫した動作とログ出力を提供します。
  * 後方互換性を維持。

* **テスト**
  * ストレージ統合を含むテストカバレッジを拡張しました。

* **ドキュメント**
  * フックAPIの注釈を追記し使い方を明確化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->